### PR TITLE
New workflow to run R CMD check on tapLock

### DIFF
--- a/.github/workflows/R-CMD-check_tapLock.yaml
+++ b/.github/workflows/R-CMD-check_tapLock.yaml
@@ -1,0 +1,64 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+# NOTE name it after the reverse dependency
+name: R-CMD-check tapLock
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,   r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+      # NOTE also checkout the remote repository of the reverse dependency
+      - uses: actions/checkout@v4
+        with:
+          repository: ixpantia/tapLock
+          ref: main
+          path: tapLock
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      # NOTE setup the dependencies of the reverse dependency
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+          working-directory: tapLock
+
+      # NOTE install the code that might break the reverse dependency
+      - name: Install local package
+        run: |
+          Rscript -e "pak::local_install()"
+
+      # NOTE run R CMD check on the reverse depencency
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
+          working-directory: tapLock
+


### PR DESCRIPTION
This PR adds a new GitHub Action to run R CMD check on tapLock on every PR. If a change to tower breaks tapLock then this workflow might catch it. The more tests there are in tapLock, the more chances breaking changes will be caught.